### PR TITLE
Client server icmp connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # unDLP
-Discreetly exfiltrate information via the ICMP protocol.
+
+Discreetly exfiltrate information via the HTTPS protocol.

--- a/client/Entity/Parser.pm
+++ b/client/Entity/Parser.pm
@@ -1,15 +1,13 @@
+#!/usr/bin/perl
+
 package Parser;
 
 use Getopt::Long;
 use Moose;
+use strict;
+use warnings;
 
 has delay => (
-    is      =>  'rw',
-    isa     =>  'Int',
-    default =>  0
-);
-
-has encryption => (
     is      =>  'rw',
     isa     =>  'Int',
     default =>  0
@@ -20,16 +18,15 @@ has file => (
     isa =>  'Str'
 );
 
+has dest => (
+    is  =>  'rw',
+    isa =>  'Str'
+);
+
 has help => (
     is      =>  'rw',
     isa     =>  'Int',
     default =>  0
-);
-
-has key => (
-    is      =>  'rw',
-    isa     =>  'Str',
-    default =>  ''
 );
 
 sub parse {
@@ -38,23 +35,24 @@ sub parse {
 
     GetOptions(
         'delay=i' => \$self->{delay},
-        'e' => \$self->{encryption},
-        'key=s' => \$self->{key},
+        'f=s' => \$self->{file},
+        'd=s' => \$self->{dest},
         'help|h' => \$self->{help}
     );
 
     $self->{file} = $args[0];
 
-    if (scalar @args < 1 || $self->help || !$self->file) {
+    if (scalar @args < 1 || $self->help || !$self->file || !$self->dest) {
         usage()
     }
 }
 
 sub usage {
-    print "\nusage: unDLP.pl FILE [-e] [-delay DELAY] [-key KEY] [--help]\n\n";
-    print "\t -e: Cipher the provided file.\n";
-    print "\t -delay: Set the transfer speed.\n";
-    print "\t -key: Set the public key used for the encryption. If not specified, the key will be retrieved from the server.\n";
+    print "\nusage: unDLP.pl -f FILE -d DESTINATION [--delay DELAY] [--help|h]\n\n";
+    print "\t -f: File to transfer.\n";
+    print "\t -d: Destination.\n";
+    print "\t --delay: Set the transfer speed.\n";
+    print "\t --help|h: Display the helper.\n";
 
     exit;
 }

--- a/client/unDLP.pl
+++ b/client/unDLP.pl
@@ -1,5 +1,6 @@
 #!/usr/bin/perl
 
+use LWP::Simple;
 use strict;
 use warnings;
 
@@ -13,7 +14,7 @@ print "
 |____/|___|  /_______  /_______ \\____|
            \\/        \\/        \\/
 
-Discreetly exfiltrate information via the ICMP protocol.
+Discreetly exfiltrate information via the HTTPS protocol.
 
 Fell free to contact the maintainer for any further questions or improvement vectors.
 Maintained by Nitrax <nitrax\@lokisec.fr>
@@ -23,3 +24,7 @@ Maintained by Nitrax <nitrax\@lokisec.fr>
 my $parser = Parser->new();
 
 $parser->parse(@ARGV);
+
+my $content = get $parser->dest;
+
+print $content;

--- a/server/server.pl
+++ b/server/server.pl
@@ -1,0 +1,32 @@
+#!/usr/bin/perl
+
+use IO::Socket::INET;
+use strict;
+use warnings;
+
+$| = 1;
+
+my $socket = new IO::Socket::INET (
+    LocalHost => 'localhost',
+    LocalPort => '443',
+    Proto => 'tcp',
+    Listen => 5,
+    Reuse => 1
+);
+
+die "cannot create socket $!\n" unless $socket;
+
+while (1) {
+    my $data = "";
+    my $client_socket = $socket->accept();
+
+    $client_socket->recv($data, 1024);
+
+    print "received data: $data\n";
+
+    $client_socket->send("ok");
+
+    shutdown($client_socket, 1);
+}
+
+$socket->close();


### PR DESCRIPTION
The project has pivoted to a new objective. Indeed, it is not possible to craft and send ICMP packet without being, prior, root on the machine. Consequently, the protocol HTTPS will be used as covert channel to exfiltrate data.